### PR TITLE
Use the checkov CLI for bridgecrew local scanning

### DIFF
--- a/content/10_module_one/1002_local_scan_cli.md
+++ b/content/10_module_one/1002_local_scan_cli.md
@@ -1,36 +1,36 @@
 ---
-title: "Bridgecrew CLI"
+title: "Checkov CLI"
 chapter: true
 weight: 102
 pre: "<b>4.2 </b>"
 ---
 
-## Run Bridgecrew CLI locally
+## Run Checkov CLI locally
 
-To demonstrate what kinds of security and compliance errors Bridgecrew can identify in CloudFormation templates, we’ll start by using Bridgecrew CLI and send the results to the Bridgecrew platform.
+To demonstrate what kinds of security and compliance errors Bridgecrew can identify in CloudFormation templates, we’ll start by using Checkov CLI and send the results to the Bridgecrew platform.
 
 Make sure you are in the `cfngoat` directory from the previous step, copy your unique Bridgecrew API token, and scan the `cfngoat.yaml` file:
 
 
 ```bash
-bridgecrew -f cfngoat.yaml --bc-api-key $YOUR_BC_API_KEY --repo bridgecrewio/cfngoat
+checkov -f cfngoat.yaml --bc-api-key $YOUR_BC_API_KEY --repo bridgecrewio/cfngoat
 ```
 
 You can also scan entire directories with `-d <path>`:
 
 ```bash
-bridgecrew -d . --framework cloudformation --bc-api-key $YOUR_BC_API_KEY --repo bridgecrewio/cfngoat
+checkov -d . --framework cloudformation --bc-api-key $YOUR_BC_API_KEY --repo bridgecrewio/cfngoat
 ```
 
 {{% notice info %}}
 <p style='text-align: left;'>
-You can use the bridgecrew CLI without --bc-api-key, the results will still display locally, without uploading to the bridgecrew cloud, for testing or local-only scan results.
+You can use the checkov CLI without --bc-api-key, the results will still display locally, without uploading to the bridgecrew cloud, for testing or local-only scan results.
 </p>
 {{% /notice %}}
 
 The results will show all the failed checks and link to a guide explaining the cause and how to fix them. Note the output also includes the filename and snippet of code that is misconfigured:
 
-![Highligting bridgecrew CLI policies](./images/highlight_cli_policies.png)
+![Highligting checkov CLI policies](./images/highlight_cli_policies.png)
 
 As you can see in the highlighted CLI output above, our demo CloudFormation repository has failing checks for two policies:
 - Ensure S3 bucket has ignore public ACLs enabled
@@ -39,23 +39,23 @@ As you can see in the highlighted CLI output above, our demo CloudFormation repo
 To get the list of policies that Bridgecrew checks for, use -l or –list:
 
 ```bash
-bridgecrew --list
+checkov --list
 ```
 
 ## Bridgecrew policies
 
-In many instances, when testing locally with the Bridgecrew CLI, you may only be interested in running just a few checks. In that case, you can add the `-c` or `--check` option:
+In many instances, when testing locally with the Checkov CLI, you may only be interested in running just a few checks. In that case, you can add the `-c` or `--check` option:
 
 
 ```
-bridgecrew -f cfngoat.yaml -c CKV_AWS_55,CKV_AWS_56
+checkov -f cfngoat.yaml -c CKV_AWS_55,CKV_AWS_56
 ```
 
 Alternatively, if you want to run all but a few checks, use the `--skip-check` option: 
 
 
 ```
-bridgecrew -f cfngoat.yaml --skip-check CKV_AWS_55,CKV_AWS_56 
+checkov -f cfngoat.yaml --skip-check CKV_AWS_55,CKV_AWS_56 
 ```
 
 Next, let’s inspect these results in the Bridgecrew dashboard.

--- a/content/20_module_two/2004_automating_iac_codepipeline.md
+++ b/content/20_module_two/2004_automating_iac_codepipeline.md
@@ -69,4 +69,4 @@ Finally, select **Create pipeline** on the review page, which will trigger your 
 
 ![AWS CodePipeline Select Repo](./images/codepipeline-create-project-github-13.png "AWS CodePipeline Select Repo")
 
-**Now we don’t need to manually run the Bridgecrew CLI; your developers will get a Bridgecrew scan every time they commit!** 
+**Now we don’t need to manually run the Checkov CLI; your developers will get a Bridgecrew scan every time they commit!** 

--- a/content/20_module_two/2006_automating_iac_github_actions.md
+++ b/content/20_module_two/2006_automating_iac_github_actions.md
@@ -87,7 +87,7 @@ Finally, save the new workflow file into your code repository by selecting **Com
 
 ![Save Github action workflow](./images/github_action_8.png "Save Github action workflow")
 
-The GitHub Action will immediatley start running the Bridgecrew CLI against the latest commit in your GFNGoat Repository.
+The GitHub Action will immediatley start running the Checkov CLI against the latest commit in your GFNGoat Repository.
 
 You can see this by selecting the **Actions** page within your CFNGoat forked repository in GitHub.
 
@@ -95,7 +95,7 @@ You will see a new workflow, titled *Bridgecrew* and a job about to run automati
 
  ![Save Github action workflow](./images/github_action_10.png "Save Github action workflow")
 
-Selecting this *job* will allow you to view the status and logging output from the pipeline, where the Bridgecrew CLI will run and output any violations found in the CFNGoat codebase.
+Selecting this *job* will allow you to view the status and logging output from the pipeline, where the Checkov CLI will run and output any violations found in the CFNGoat codebase.
 
  ![Github action workflow logs](./images/github_action_11.png "Github action workflow logs")
 

--- a/content/20_module_two/_index.md
+++ b/content/20_module_two/_index.md
@@ -6,7 +6,7 @@ pre: "<b>5 </b>"
 ---
 
 # MODULE - AUTOMATE
-In the previous section, we used the Bridgecrew CLI to do some quick scanning before committing a change into the code repository. That’s great for checking work here and there but forcing every developer to run a scan on their machines before every single commit isn’t reasonable or feasible. To continuously audit code, automation and built-in workflows are key. With Bridgecrew, you can automate your infrastructure scanning along with the rest of your unit and integration testing by embedding it into your version control system and CI/CD pipeline.
+In the previous section, we used the Checkov CLI to do some quick scanning before committing a change into the code repository. That’s great for checking work here and there but forcing every developer to run a scan on their machines before every single commit isn’t reasonable or feasible. To continuously audit code, automation and built-in workflows are key. With Bridgecrew, you can automate your infrastructure scanning along with the rest of your unit and integration testing by embedding it into your version control system and CI/CD pipeline.
 
 This module will show you how to prevent cloud security issues from being deployed by integrating Bridgecrew with both the AWS developer tools suite, and GitHub Actions.
 

--- a/content/6_prerequisites/601_setting_up_bridgecrew_account.md
+++ b/content/6_prerequisites/601_setting_up_bridgecrew_account.md
@@ -9,8 +9,8 @@ You’ll need to sign up for a free Bridgecrew account to follow along with this
 
 ![Signup to Bridgecrew](./images/signup_bridgecrew.png)
 
-## Bridgecrew CLI
-In this tutorial, we’re also going to use Bridgecrew CLI. The CLI works on Windows, Mac, and Linux. You can install it with pip:
+## Checkov CLI
+In this tutorial, we’re also going to use Checkov CLI. The CLI works on Windows, Mac, and Linux. You can install it with pip:
 
 ```bash
 pip3 install bridgecrew


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Change from bridgecrew cli to checkov cli for consistency with bridgecrew cli naming.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
